### PR TITLE
Rename minus operator test

### DIFF
--- a/src/evaluator/evaluator_test.go
+++ b/src/evaluator/evaluator_test.go
@@ -156,7 +156,7 @@ func TestBangOperator(t *testing.T) {
 	}
 }
 
-func TestMinusperator(t *testing.T) {
+func TestMinusOperator(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected int64


### PR DESCRIPTION
## Summary
- fix typo in evaluator test name
- ensure no remaining references to old test name

## Testing
- `go test ./...` *(fails: downloading go toolchain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842cab40a68832bbf609a11bf23d035