### PR TITLE
Fix minor comment typo

### DIFF
--- a/src/ast/ast.go
+++ b/src/ast/ast.go
@@ -180,9 +180,9 @@ func (b *Boolean) expressionNode()      {}
 func (b *Boolean) String() string       { return b.Token.Literal }
 
 type PrefixExpression struct {
-	Token    token.Token // The prfix token e.g "-"
-	Operator string
-	Right    Expression
+       Token    token.Token // The prefix token e.g "-"
+       Operator string
+       Right    Expression
 }
 
 func (pe *PrefixExpression) TokenLiteral() string { return pe.Token.Literal }


### PR DESCRIPTION
## Summary
- correct comment about prefix token in `PrefixExpression`

## Testing
- `go vet ./...` *(fails: Forbidden)
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842cabffa6c832b8da97d1c0087129a